### PR TITLE
Fix/detect vscroll bar height dynamically

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -993,13 +993,17 @@
 
                             // Detect if horizontal according to the class
                             if (angular.element(e.target).hasClass("horizontal")) {
-                                scrollRatio = e.target.scrollLeft / (e.target.scrollWidth);
+                                // add `0` value check to ensure that the ratio is not NaN.
+                                // If that happens, scope.$$setCenterColumnsData will not behave properly
+                                scrollRatio = e.target.scrollWidth && e.target.scrollLeft / e.target.scrollWidth;
                                 scope.$$scrollPosition.left = Math.round(scrollRatio * (scope.data[0].length - scope.$$leftFixedColumns.length - scope.$$rightFixedColumns.length));
 
                             } else
                             // Detect if vertical according to the class
                             if (angular.element(e.target).hasClass("vertical")) {
-                                scrollRatio = e.target.scrollTop / (e.target.scrollHeight);
+                                // add `0` value check to ensure that the ratio is not NaN.
+                                // If that happens, scope.$$setCenterColumnsData will not behave properly
+                                scrollRatio = e.target.scrollHeight && e.target.scrollTop / e.target.scrollHeight;
                                 scope.$$scrollPosition.top = Math.round(scrollRatio * (scope.data.length - scope.$$headerRows.length - scope.$$footerRows.length));
                             } else {
                                 // If other scroll event do not process data redraw


### PR DESCRIPTION
This PR proposes to fix an issue with the calculation of the vertical scroll bar height.

It needs to be detected dynamically instead of only at the first time because the vertical scrollbar may change of size due to other external reasons.

> e.g. When the ng-cells directive is used inside a hidden DIV at the beginning and is then shown after some user interaction.
> At first, the parent block of the directive is hidden (display:none), so the vertical scrollbar height is 0. 
> Then when the parent block is displayed, the vertical scrollbar height will have a positive value.
